### PR TITLE
Add meta data to partners page for social media link preview

### DIFF
--- a/pages/partners.html
+++ b/pages/partners.html
@@ -10,6 +10,20 @@
 .. type: text
 -->
 
+<head>
+  <title>Open Science Labs Partners</title>
+  <meta property="og:title" content="Open Science Labs Partners">
+  <meta name="description" content="Check out OSL Partners. If you want to become a partner, send us a request via Github">
+  <meta property="og:description" content="Check out OSL Partners. If you want to become a partner, send us a request via Github.">
+  <meta property="og:image" content="https://opensciencelabs.org/images/logo.png">
+  <meta name="image" content="https://opensciencelabs.org/images/logo.png">
+
+  <meta name="twitter:title" content="Open Science Labs Partners">
+  <meta name="twitter:description" content="Check out OSL Partners. If you want to become a partner, send us a request via Github.">
+  <meta name="twitter:image" content="https://opensciencelabs.org/images/logo.png">
+  <meta name="twitter:site" content="@opensciencelabs">
+</head>
+
 <link rel="stylesheet" href="https://use.fontawesome.com/aa402b3835.css">
 
 <style>


### PR DESCRIPTION
Fix #54 

PS: I was unable to find the right image ratio for the preview, so I'm not sure how it will work until merged to production. But the error that caused css to show in preview seems to be fixed using https://socialsharepreview.com/ extension. 