### PR TITLE
Move Luis Gago to board in team page

### DIFF
--- a/pages/team.html
+++ b/pages/team.html
@@ -73,8 +73,20 @@ can apply to our team.
       </p>
     </div>
   </div>
+  <div class="card">
+    <img src="https://avatars.githubusercontent.com/u/4383323?v=4"
+     class="card-img-top" alt="Luis Gago Casas">
+    <div class="card-body">
+      <h5 class="card-title">Luis Gago Casas</h5>
+      <p class="card-text">
+        CEO and Owner at AyPhu
+      </p>
+      <p class="card-text"><a href="https://github.com/luisgagocasas"><i
+           class="fa fa-brands fa-github-square position-static text-dark"></i></a>
+      </p>
+    </div>
+  </div>
 </div>
-
 
 <h2>Contributors</h2>
 
@@ -131,19 +143,6 @@ can apply to our team.
         new ways for open knowledge survival in a world plenty of selfishness.
       </p>
       <p class="card-text"><a href="https://github.com/petrizzo"><i
-           class="fa fa-brands fa-github-square position-static text-dark"></i></a>
-      </p>
-    </div>
-  </div>
-  <div class="card">
-    <img src="https://avatars.githubusercontent.com/u/4383323?v=4"
-     class="card-img-top" alt="Luis Gago Casas">
-    <div class="card-body">
-      <h5 class="card-title">Luis Gago Casas</h5>
-      <p class="card-text">
-        CEO and Owner at AyPhu
-      </p>
-      <p class="card-text"><a href="https://github.com/luisgagocasas"><i
            class="fa fa-brands fa-github-square position-static text-dark"></i></a>
       </p>
     </div>


### PR DESCRIPTION
Note: the white space between the cards are the default view of Bootstrap `card-columns`